### PR TITLE
Update forecast display to use flexbox layout and improve styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,10 +37,11 @@ function displayForecast(daily) {
     daily.time.slice(1, 8).forEach((day, index) => {
         const forecastElement = document.createElement('div');
         forecastElement.innerHTML = `
-            <div>
-                <p>${new Date(day).toLocaleDateString(undefined, { weekday: 'short' })}</p>
-                <p>${daily.temperature_2m_max[index]} °C / ${daily.temperature_2m_min[index]} °C</p>
-                <p>${daily.precipitation_sum[index]} mm</p>
+            <div class="row">
+                <span>${new Date(day).toLocaleDateString(undefined, { weekday: 'short' })}</span>
+                <span>${daily.precipitation_sum[index]} mm</span>
+                <span>${daily.temperature_2m_min[index]} °C</span>
+                <span>${daily.temperature_2m_max[index]} °C</span>
             </div>
         `;
         forecastContainer.appendChild(forecastElement);

--- a/styles.css
+++ b/styles.css
@@ -22,10 +22,10 @@ body {
     margin-top: 20px;
 }
 
-#forecast div {
+#forecast div.row {
     display: flex;
     justify-content: space-between;
-    padding: 10px;
+    padding: 10px 32px;
     background-color: #e0e0e0;
     border-radius: 4px;
     margin-bottom: 10px;
@@ -98,3 +98,4 @@ body {
 .bg-calm.bg-night {
     background-color: #556b2f;
 }
+


### PR DESCRIPTION
* **app.js**
  - Change forecast display to use `div` elements with class `row` and `span` elements for each data point
  - Adjust order of displayed data points

* **styles.css**
  - Update forecast styling to target `div.row` instead of `div`
  - Adjust padding for forecast rows
  - Add extra line break for better readability